### PR TITLE
Track fail recover

### DIFF
--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -84,7 +84,7 @@ void trackingThread(Tracking &tracker, int uart_fd, Point p1, Point p2, VideoTra
     // need to start up transmitter thread and send track-end to app
     transmitTrackingFrame = false;
     char msg[32];
-    snprintf(msg, sizeof(msg), "track-end");
+    snprintf(msg, sizeof(msg), "track-fail");
     int num_wrBytes = write(uart_fd, msg, strlen(msg));
     std::thread videoTxThread(transmitterThread, std::ref(vidTx), std::ref(video));
     videoTxThread.detach(); // video thread runs independently

--- a/tracker.sh
+++ b/tracker.sh
@@ -4,5 +4,7 @@
 # To run: ./disable_serial_getty.sh
 sudo systemctl stop serial-getty@ttyS0.service
 sudo systemctl disable serial-getty@ttyS0.service
-cd Desktop/MobileTargetTracking/build
+cd build
+# cd Desktop/MobileTargetTracking/build
+make TestMain
 sudo ./TestMain


### PR DESCRIPTION
We are now recovering from tracking fail by transmitting the regular frames when a tracking failure occurs.
We are now creating tracking object in tracking thread to avoid holding onto previous bbox reference.